### PR TITLE
fix: change to `optionalDependencies`

### DIFF
--- a/packages/vue-i18n-bridge/package.json
+++ b/packages/vue-i18n-bridge/package.json
@@ -6,20 +6,19 @@
     "postinstall": "node ./scripts/postinstall.js"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-rc.1",
-    "vue-i18n": "^8.26.1 || ^9.2.0-beta.25 || ^9.3.0-beta.3",
-    "vue-i18n-bridge": "^9.2.0-beta.25 || ^9.3.0-beta.3"
+    "vue-i18n": "^8.26.1 || ^9.2.0-beta.25 || ^9.3.0-beta.5",
+    "vue-i18n-bridge": "^9.2.0-beta.25 || ^9.3.0-beta.5"
   },
   "peerDependenciesMeta": {
-    "@vue/composition-api": {
-      "optional": true
-    },
     "vue-i18n": {
       "optional": true
     },
     "vue-i18n-bridge": {
       "optional": true
     }
+  },
+  "optionalDependencies": {
+    "@vue/composition-api": "^1.0.0-rc.1"
   },
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",

--- a/packages/vue-router-bridge/package.json
+++ b/packages/vue-router-bridge/package.json
@@ -9,16 +9,15 @@
     "vue-demi": "^0.13.5"
   },
   "peerDependencies": {
-    "@vue/composition-api": "^1.0.0-rc.1",
     "vue-router": "^4.0.0-0 || ^3.0.0"
   },
   "peerDependenciesMeta": {
-    "@vue/composition-api": {
-      "optional": true
-    },
     "vue-router": {
       "optional": true
     }
+  },
+  "optionalDependencies": {
+    "@vue/composition-api": "^1.0.0-rc.1"
   },
   "main": "lib/index.cjs",
   "module": "lib/index.mjs",


### PR DESCRIPTION
<!-- DO NOT IGNORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/intlify/bridging/blob/main/CONTRIBUTING.md).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description
In Vue 2.7, @vue/compostion-api is not required. In @vue/compostion-api peerDependeces, the Vue version is defined as 2.
vue-i18n-routing works with Vue 2 / Vue 3, but will not work in a Vue 3 environment if peerDepependeces is left as is.

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Linked Issues

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
